### PR TITLE
adds build and test npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   "config": {
     "name": "phaser-spine"
   },
+  "scripts": {
+    "build": "grunt dist",
+    "test": "exit 0"
+  },
   "devDependencies": {
     "grunt": "1.0.x",
     "grunt-banner": "^0.6.0",


### PR DESCRIPTION
These scripts are expected by the CodeBuild module that we are going to use to publish the module.

The `build` command is self-explanatory, but `test` looks a bit odd. There is a pipeline step that runs `npm run test` and needs to `exit 0` to pass. Since there are not actually any tests in this project I am just making sure it always passes.